### PR TITLE
Update carton version from 0.12.2 to 0.13.0 so we can use --debug-info and --Xswiftc flags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }} 
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
-          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.13.0
+          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:main
           SWIFT_TAG=swift-wasm-5.5-SNAPSHOT-2022-03-10-a
           NODE_VERSION=16.x
           OPEN_JDK_VERSION=11

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }} 
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
-          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.12.2
+          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.13.0
           SWIFT_TAG=swift-wasm-5.5-SNAPSHOT-2022-03-10-a
           NODE_VERSION=16.x
           OPEN_JDK_VERSION=11

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The collection of tools included are:
 
 ```
 $ docker build \
-    --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/norio-nomura/swiftlint:0.45.1_swift-5.5.0 \
-    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.13.0 \
+    --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
+    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:main \
+    --build-arg SWIFT_TAG=swift-wasm-5.5-SNAPSHOT-2022-03-10-a \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
     --build-arg CYPRESS_VERSION=9.5.1 \
@@ -33,7 +34,7 @@ Here you are a list of the tagged dockers with the specific tools version includ
 
 ### 0.0.7:
 - Swift Web Assembly toolchain => `swift-wasm-5.5-SNAPSHOT-2022-03-10-a`
-- Carton => `0.13.0`
+- Carton => `main`
 - Binaryen => `105`
 - NodeJS => `v16.13.2`
 - Npm => `8.1.2`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The collection of tools included are:
 ```
 $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/norio-nomura/swiftlint:0.45.1_swift-5.5.0 \
-    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.12.1 \
+    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.13.0 \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
     --build-arg CYPRESS_VERSION=9.5.1 \
@@ -30,6 +30,19 @@ $ docker build \
 
 ## [TAGGED VERSIONS](https://github.com/GoodNotes/swiftwasm-frontend-docker/pkgs/container/swiftwasm-frontend-docker)
 Here you are a list of the tagged dockers with the specific tools version included.
+
+### 0.0.7:
+- Swift Web Assembly toolchain => `swift-wasm-5.5-SNAPSHOT-2022-03-10-a`
+- Carton => `0.13.0`
+- Binaryen => `105`
+- NodeJS => `v16.13.2`
+- Npm => `8.1.2`
+- Npx => `8.1.2`
+- Yarn => `1.22.17`
+- SwiftLint => `0.46.5`
+- Cypress => `9.5.1`
+- Brotli => `1.0.9`
+- Chrome => `95.0.4638.69`
 
 ### 0.0.6:
 - Swift Web Assembly toolchain => `swift-wasm-5.5-SNAPSHOT-2022-03-10-a`


### PR DESCRIPTION
Carton update needed for https://github.com/GoodNotes/GoodNotes-5/pull/7548.