### PR TITLE
Add firefox, update chrome and get back to the fastest cypress version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,5 +49,6 @@ jobs:
           SWIFT_TAG=swift-wasm-5.6.0-RELEASE
           NODE_VERSION=16.x
           OPEN_JDK_VERSION=11
-          CYPRESS_VERSION=9.5.1
-          CHROME_VERSION=95.0.4638.69
+          CYPRESS_VERSION=8.5.0
+          CHROME_VERSION=101.0.4951.54
+          FIREFOX_VERSION=99.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,14 @@ RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.co
 RUN dpkg -i /usr/src/google-chrome-stable_current_amd64.deb
 RUN apt-get install -f -y
 
+# Install firefox
+ARG FIREFOX_VERSION
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 \
+  https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
 # Intall swift lint from docker
 COPY --from=swiftLint /usr/bin/swiftlint /usr/bin/swiftlint
 COPY --from=swiftLint /usr/lib/libsourcekitdInProc.so /usr/lib/

--- a/README.md
+++ b/README.md
@@ -25,12 +25,27 @@ $ docker build \
     --build-arg SWIFT_TAG=swift-wasm-5.6.0-RELEASE \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
-    --build-arg CYPRESS_VERSION=9.5.1 \
-    --build-arg CHROME_VERSION=95.0.4638.69 - < Dockerfile
+    --build-arg CYPRESS_VERSION=8.5.0 \
+    --build-arg FIREFOX_VERSION=99.0.1 \
+    --build-arg CHROME_VERSION=101.0.4951.54 - < Dockerfile
 ```
 
 ## [TAGGED VERSIONS](https://github.com/GoodNotes/swiftwasm-frontend-docker/pkgs/container/swiftwasm-frontend-docker)
 Here you are a list of the tagged dockers with the specific tools version included.
+
+### 0.0.10:
+- Swift Web Assembly toolchain => `swift-wasm-5.6.0-RELEASE`
+- Carton => `0.14.1`
+- Binaryen => `105`
+- NodeJS => `v16.13.2`
+- Npm => `8.1.2`
+- Npx => `8.1.2`
+- Yarn => `1.22.17`
+- SwiftLint => `0.46.5`
+- Cypress => `8.5.0`
+- Brotli => `1.0.9`
+- Chrome => `101.0.4951.54`
+- Firefox => `99.0.1`
 
 ### 0.0.9:
 - Swift Web Assembly toolchain => `swift-wasm-5.6.0-RELEASE`


### PR DESCRIPTION
In order to be able to test different browsers and speed the execution of our test not only in CI but also in our local machines I've noticed, we would need to update the Chrome version, add Firefox just in case we use it in the future, and also downgrade Cypress version back to 8.5.0. Once cypress perf issue is fixed, we can get back to the latest version published.