### PR TITLE
Update toolchain to swift-wasm-5.6-SNAPSHOT-2022-06-30-a

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
     --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.16.0 \
     --build-arg SWIFT_DOCKER_IMAGE=swift:5.6 \
-    --build-arg SWIFT_TAG=swift-wasm-5.6.0-RELEASE \
+    --build-arg SWIFT_TAG=swift-wasm-5.6-SNAPSHOT-2022-06-30-a \
     --build-arg SWIFT_FORMAT_TAG=0.50600.0 \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
@@ -37,6 +37,23 @@ $ docker build \
 
 ## [TAGGED VERSIONS](https://github.com/GoodNotes/swiftwasm-frontend-docker/pkgs/container/swiftwasm-frontend-docker)
 Here you are a list of the tagged dockers with the specific tools version included.
+
+### 0.0.16:
+- Swift Web Assembly toolchain => `swift-wasm-5.6-SNAPSHOT-2022-06-30-a`
+- Carton => `0.16.0`
+- Binaryen => `105`
+- NodeJS => `v16.13.2`
+- Npm => `8.1.2`
+- Npx => `8.1.2`
+- Yarn => `1.22.17`
+- SwiftLint => `0.46.5`
+- SwiftFormat => `0.50600.1`
+- Cypress => `8.5.0`
+- Brotli => `1.0.9`
+- Chrome => `101.0.4951.54`
+- ChromeDriver => `101.0.4951.41`
+- Firefox => `99.0.1`
+- Sentry Symbolicator => `0.5.0`
 
 ### 0.0.15:
 - Swift Web Assembly toolchain => `swift-wasm-5.6.0-RELEASE`


### PR DESCRIPTION
For XCTest async support and backported `async let` fix.