### PR TITLE
Update carton to 0.17.0, which is compatible with 5.7 toolchain

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }} 
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
-          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.16.1
+          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.17.0
           SWIFT_DOCKER_IMAGE=swift:5.6
           SWIFT_TAG=swift-wasm-5.7.1-RELEASE
           SWIFT_FORMAT_TAG=0.50600.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,9 +48,9 @@ jobs:
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
           CARTON_TAG=0.17.0
-          SWIFT_DOCKER_IMAGE=swift:5.7-focal
+          SWIFT_DOCKER_IMAGE=swift:5.7.0-focal
           SWIFT_TAG=swift-wasm-5.7.1-RELEASE
-          SWIFT_FORMAT_TAG=0.50700.1
+          SWIFT_FORMAT_TAG=0.50700.0
           NODE_VERSION=16.x
           OPEN_JDK_VERSION=11
           CYPRESS_VERSION=8.5.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           CARTON_TAG=0.17.0
           SWIFT_DOCKER_IMAGE=swift:5.7-focal
           SWIFT_TAG=swift-wasm-5.7.1-RELEASE
-          SWIFT_FORMAT_TAG=0.50600.0
+          SWIFT_FORMAT_TAG=0.50700.1
           NODE_VERSION=16.x
           OPEN_JDK_VERSION=11
           CYPRESS_VERSION=8.5.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
           CARTON_TAG=0.17.0
-          SWIFT_DOCKER_IMAGE=swift:5.6
+          SWIFT_DOCKER_IMAGE=swift:5.7-focal
           SWIFT_TAG=swift-wasm-5.7.1-RELEASE
           SWIFT_FORMAT_TAG=0.50600.0
           NODE_VERSION=16.x

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }} 
         build-args: |
           SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5
-          CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.17.0
+          CARTON_TAG=0.17.0
           SWIFT_DOCKER_IMAGE=swift:5.6
           SWIFT_TAG=swift-wasm-5.7.1-RELEASE
           SWIFT_FORMAT_TAG=0.50600.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN git clone https://github.com/apple/swift-format.git && \
     git checkout "tags/$SWIFT_FORMAT_TAG" && \
     swift build -c release
 
-FROM ubuntu:latest as binaryen
+FROM ubuntu:20.04 as binaryen
 
 RUN apt-get update && apt-get install -y curl
 RUN curl -L -v -o binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_105/binaryen-version_105-x86_64-linux.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,15 @@ RUN git clone https://github.com/swiftwasm/carton.git && \
 FROM $SWIFT_DOCKER_IMAGE as swift-format-builder
 
 ARG SWIFT_FORMAT_TAG 
+
+# FIXME(katei): The sed hack is required to pin the swift-syntax version to `0.50700.0`.
+# Without this hack, SwiftPM uses swift-syntax `0.50700.1`, which is incompatible with 5.7.0
+# Docker image. Remove the hack after Apple folks will release an image compatible with swift-syntax
+# `0.50700.1` (probably `swift:5.7.1`?)
 RUN git clone https://github.com/apple/swift-format.git && \
     cd swift-format && \
     git checkout "tags/$SWIFT_FORMAT_TAG" && \
+    sed -i -e 's/.upToNextMinor(from: "0.50700.0")/exact: "0.50700.0"/' Package.swift && \
     swift build -c release
 
 FROM ubuntu:20.04 as binaryen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 ARG SWIFLINT_DOCKER_IMAGE
-ARG CARTON_DOCKER_IMAGE
 ARG SWIFT_DOCKER_IMAGE
 
 FROM $SWIFLINT_DOCKER_IMAGE as swiftLint
 
-FROM $CARTON_DOCKER_IMAGE as carton-builder
+FROM $SWIFT_DOCKER_IMAGE as carton-builder
+ARG CARTON_TAG
+RUN apt-get update && apt-get install -y libsqlite3-dev
+RUN git clone https://github.com/swiftwasm/carton.git && \
+    cd carton && \
+    git checkout "tags/$CARTON_TAG" && \
+    swift build -c release && \
+    mv .build/release/carton /usr/bin
 
 FROM $SWIFT_DOCKER_IMAGE as swift-format-builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG SYMBOLICATOR_VERSION
 RUN apt-get update && apt-get install -y curl
 RUN curl -L -v -o wasm-split https://github.com/getsentry/symbolicator/releases/download/$SYMBOLICATOR_VERSION/wasm-split-Linux-x86_64 && chmod +x wasm-split
 
-FROM ubuntu:20.04 as swiftwasm-builder
+FROM $SWIFT_DOCKER_IMAGE-slim as swiftwasm-builder
 
 ARG SWIFT_TAG
 ARG NODE_VERSION
@@ -116,8 +116,6 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 \
 # Intall swift lint from docker
 COPY --from=swiftLint /usr/bin/swiftlint /usr/bin/swiftlint
 COPY --from=swiftLint /usr/lib/libsourcekitdInProc.so /usr/lib/
-COPY --from=swiftLint /usr/lib/libBlocksRuntime.so /usr/lib/
-COPY --from=swiftLint /usr/lib/libdispatch.so /usr/lib/
 
 # Install latest carton tool
 COPY --from=carton-builder /usr/bin/carton /usr/bin/carton
@@ -126,8 +124,6 @@ COPY --from=carton-builder /usr/bin/carton /usr/bin/carton
 COPY --from=binaryen binaryen-version_105/bin/* /usr/local/bin
 
 # Install swift format 
-COPY --from=swift-format-builder /lib/x86_64-linux-gnu/libtinfo.so.* /usr/lib/
-COPY --from=swift-format-builder /usr/lib/swift/linux/*.so* /usr/lib/
 COPY --from=swift-format-builder swift-format/.build/release/swift-format /usr/local/bin/swift-format
 
 COPY --from=symbolicator-builder wasm-split /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The collection of tools included are:
 $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
     --build-arg CARTON_TAG=0.17.0 \
-    --build-arg SWIFT_DOCKER_IMAGE=swift:5.7-focal \
+    --build-arg SWIFT_DOCKER_IMAGE=swift:5.7.0-focal \
     --build-arg SWIFT_TAG=swift-wasm-5.7.1-RELEASE \
-    --build-arg SWIFT_FORMAT_TAG=0.50700.1 \
+    --build-arg SWIFT_FORMAT_TAG=0.50700.0 \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
     --build-arg CYPRESS_VERSION=8.5.0 \
@@ -47,7 +47,7 @@ Here you are a list of the tagged dockers with the specific tools version includ
 - Npx => `8.1.2`
 - Yarn => `1.22.17`
 - SwiftLint => `0.46.5`
-- SwiftFormat => `0.50700.1`
+- SwiftFormat => `0.50700.0`
 - Cypress => `10.6.0`
 - Brotli => `1.0.9`
 - Chrome => `101.0.4951.54`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The collection of tools included are:
 ```
 $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
-    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.17.0 \
+    --build-arg CARTON_TAG=0.17.0 \
     --build-arg SWIFT_DOCKER_IMAGE=swift:5.6 \
     --build-arg SWIFT_TAG=swift-wasm-5.7.1-RELEASE \
     --build-arg SWIFT_FORMAT_TAG=0.50600.0 \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The collection of tools included are:
 ```
 $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
-    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.16.1 \
+    --build-arg CARTON_DOCKER_IMAGE=ghcr.io/swiftwasm/carton:0.17.0 \
     --build-arg SWIFT_DOCKER_IMAGE=swift:5.6 \
     --build-arg SWIFT_TAG=swift-wasm-5.7.1-RELEASE \
     --build-arg SWIFT_FORMAT_TAG=0.50600.0 \
@@ -37,6 +37,23 @@ $ docker build \
 
 ## [TAGGED VERSIONS](https://github.com/GoodNotes/swiftwasm-frontend-docker/pkgs/container/swiftwasm-frontend-docker)
 Here you are a list of the tagged dockers with the specific tools version included.
+
+### 0.0.22:
+- Swift Web Assembly toolchain => `swift-wasm-5.7.1-RELEASE`
+- Carton => `0.17.0`
+- Binaryen => `105`
+- NodeJS => `v16.13.2`
+- Npm => `8.1.2`
+- Npx => `8.1.2`
+- Yarn => `1.22.17`
+- SwiftLint => `0.46.5`
+- SwiftFormat => `0.50600.1`
+- Cypress => `10.6.0`
+- Brotli => `1.0.9`
+- Chrome => `101.0.4951.54`
+- ChromeDriver => `101.0.4951.41`
+- Firefox => `99.0.1`
+- Sentry Symbolicator => `0.5.0`
 
 ### 0.0.21:
 - Swift Web Assembly toolchain => `swift-wasm-5.7.1-RELEASE`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The collection of tools included are:
 $ docker build \
     --build-arg SWIFLINT_DOCKER_IMAGE=ghcr.io/realm/swiftlint:0.46.5 \
     --build-arg CARTON_TAG=0.17.0 \
-    --build-arg SWIFT_DOCKER_IMAGE=swift:5.6 \
+    --build-arg SWIFT_DOCKER_IMAGE=swift:5.7-focal \
     --build-arg SWIFT_TAG=swift-wasm-5.7.1-RELEASE \
     --build-arg SWIFT_FORMAT_TAG=0.50600.0 \
     --build-arg NODE_VERSION=16.x \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ docker build \
     --build-arg CARTON_TAG=0.17.0 \
     --build-arg SWIFT_DOCKER_IMAGE=swift:5.7-focal \
     --build-arg SWIFT_TAG=swift-wasm-5.7.1-RELEASE \
-    --build-arg SWIFT_FORMAT_TAG=0.50600.0 \
+    --build-arg SWIFT_FORMAT_TAG=0.50700.1 \
     --build-arg NODE_VERSION=16.x \
     --build-arg OPEN_JDK_VERSION=11 \
     --build-arg CYPRESS_VERSION=8.5.0 \
@@ -47,7 +47,7 @@ Here you are a list of the tagged dockers with the specific tools version includ
 - Npx => `8.1.2`
 - Yarn => `1.22.17`
 - SwiftLint => `0.46.5`
-- SwiftFormat => `0.50600.1`
+- SwiftFormat => `0.50700.1`
 - Cypress => `10.6.0`
 - Brotli => `1.0.9`
 - Chrome => `101.0.4951.54`


### PR DESCRIPTION
I forgot to update carton 😓  Carton 0.16.1 has an issue around execution model selection, and it uses command-line model when using 5.7 toolchain even though we should use reactor model. https://github.com/swiftwasm/carton/pull/381/files#diff-0f8cf16b49566a01e952c8c1277adbbe6e7013c47fdc9e41e0688e3bcc2c7113L368-L372