### PR TITLE
Include wasm-snip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN curl -L -v -o binaryen.tar.gz https://github.com/WebAssembly/binaryen/releas
 RUN tar xzvf binaryen.tar.gz
 
 # Install cargo + wasm-snip
+RUN apt-get install -y build-essential
 RUN curl https://sh.rustup.rs -sSf > rustup.sh
 RUN chmod 755 rustup.sh
 RUN ./rustup.sh -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ RUN apt-get update && apt-get install -y curl
 RUN curl -L -v -o binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_105/binaryen-version_105-x86_64-linux.tar.gz
 RUN tar xzvf binaryen.tar.gz
 
+# Install cargo + wasm-snip
+RUN curl https://sh.rustup.rs -sSf > rustup.sh
+RUN chmod 755 rustup.sh
+RUN ./rustup.sh -y
+RUN ~/.cargo/bin/cargo install wasm-snip
+
 FROM ubuntu:20.04 as symbolicator-builder
 
 ARG SYMBOLICATOR_VERSION


### PR DESCRIPTION
We want to use ``wasm-snip`` in order to reduce the size of the binary. To be able to do it from our CI we need to include it in our docker image.