### PR TITLE
Fix typo issue from `tecnologies` to `technologies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Repo for generating a docker image with all the needed tools usually for a Frontend Project with Swift WebAssembly.
 
-Creating a frontend application using Swift WASM and React tecnologies requires the use of several tools. 
+Creating a frontend application using Swift WASM and React technologies requires the use of several tools. 
 This is why in order to speed up and simplify logic in the CI we have created this docker image, including all the needed tools using either for compile project, test it and even generate the artifacts.
 
 


### PR DESCRIPTION
Fix typo issue from `tecnologies` to `technologies`.